### PR TITLE
update to preview 1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.0.0"
-wgpu4k = "0.0.0-SNAPSHOT"
+wgpu4k = "preview-1"
 korge = "5.4.0"
 coroutines = "1.8.0"
 


### PR DESCRIPTION
The version of wgpu4k specified in gradle has been updated from "0.0.0-SNAPSHOT" to "preview-1". This change now aligns with the most recent release version of the wgpu4k library.