### PR TITLE
Remove unused surface texture usage

### DIFF
--- a/shared/src/commonMain/kotlin/render.kt
+++ b/shared/src/commonMain/kotlin/render.kt
@@ -15,7 +15,7 @@ fun AutoClosableContext.createScene(context: WGPUContext): RotatingCubeScene {
             CanvasConfiguration(
                 device = context.device,
                 format = context.renderingContext.textureFormat,
-                usage = setOf(TextureUsage.renderattachment, TextureUsage.copysrc),
+                usage = setOf(TextureUsage.renderattachment),
                 alphaMode = alphaMode
             )
         )


### PR DESCRIPTION
Removed TextureUsage.copysrc from the set of usage arguments in CanvasConfiguration. This change ensures that the configuration only includes necessary usage attributes for rendering, streamlining the code and potentially improving performance.