### PR TITLE
Fix macOS architecture mapping in build script

### DIFF
--- a/hello-cube/build.gradle.kts
+++ b/hello-cube/build.gradle.kts
@@ -50,8 +50,8 @@ kotlin {
 
     when(Platform.os) {
          Os.MacOs -> when(Platform.architecture) {
-             Architecture.X86_64 -> macosArm64("osx")
-             Architecture.AARCH64 -> macosX64("osx")
+             Architecture.X86_64 -> macosX64("osx")
+             Architecture.AARCH64 -> macosArm64("osx")
          }
         else -> null // Not supported
     }?.let { nativeTarget ->


### PR DESCRIPTION
Corrected the mapping of macOS architectures to their respective targets. X86_64 now maps to macosX64, and AARCH64 maps to macosArm64. This ensures proper configuration for macOS builds based on architecture.