### PR TITLE
Update wgpu4k version to 0.1.0.M2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.10.1"
 kotlin = "2.1.20"
-wgpu4k = "0.1.0.M1"
+wgpu4k = "0.1.0.M2"
 korge = "6.0.0"
 coroutines = "1.10.2"
 agp = "8.7.3"


### PR DESCRIPTION
This change updates the wgpu4k dependency from version 0.1.0.M1 to 0.1.0.M2 in the libs.versions.toml configuration file. The update likely includes improvements or bug fixes provided in the newer release.